### PR TITLE
use image timestamp

### DIFF
--- a/depthimage_to_navscan_rgbd/src/depthimage_to_navscan_rgbd.cpp
+++ b/depthimage_to_navscan_rgbd/src/depthimage_to_navscan_rgbd.cpp
@@ -98,7 +98,7 @@ int main(int argc, char** argv)
         // fill output message
         sensor_msgs::PointCloud2 pointcloud2_msg;
         pointcloud2_msg.header.frame_id = frame_id;
-        pointcloud2_msg.header.stamp = ros::Time::now();
+        pointcloud2_msg.header.stamp = ros::Time(image->getTimestamp());
 
         pointcloud2_msg.height = 1;
 

--- a/depthimage_to_navscan_rgbd/src/depthimage_to_navscan_rgbd.cpp
+++ b/depthimage_to_navscan_rgbd/src/depthimage_to_navscan_rgbd.cpp
@@ -98,7 +98,7 @@ int main(int argc, char** argv)
         // fill output message
         sensor_msgs::PointCloud2 pointcloud2_msg;
         pointcloud2_msg.header.frame_id = frame_id;
-        pointcloud2_msg.header.stamp = ros::Time(image->getTimestamp());
+        pointcloud2_msg.header.stamp.fromSec(image->getTimestamp());
 
         pointcloud2_msg.height = 1;
 


### PR DESCRIPTION
Solves problem where movement of the base frame causes a desynchronization in the scan.